### PR TITLE
Fixed bug where image only is not vertically centered

### DIFF
--- a/DMPagerViewController.podspec
+++ b/DMPagerViewController.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "DMPagerViewController"
-  s.version          = "0.1.0"
+  s.version          = "0.1.1"
   s.summary          = "DMPagerViewController is page navigation controller like the one used in Twitter or Tinder"
   s.description      = <<-DESC
                        DMPagerViewController page navigation controller which aims to mimics the one used in Twitter or Tinder with navigation bar on top and a parallax effect on scrolling. 

--- a/Pod/Classes/DMPagerNavigationBar.m
+++ b/Pod/Classes/DMPagerNavigationBar.m
@@ -64,13 +64,13 @@
 }
 
 - (void)setRenderingMode:(DMPagerNavigationBarItemMode)renderingMode {
-	if (_renderingMode == renderingMode) return;
-	_renderingMode = renderingMode;
-	_iconView.hidden = !(_renderingMode == DMPagerNavigationBarItemModeOnlyImage || _renderingMode == DMPagerNavigationBarItemModeTextAndImage);
-	_titleLabel.hidden = !(_renderingMode == DMPagerNavigationBarItemModeOnlyText || _renderingMode == DMPagerNavigationBarItemModeTextAndImage);
-	[self layoutSubviews];
+    if (_renderingMode == renderingMode) {
+        return;
+    }
+    _renderingMode = renderingMode;
+    _iconView.hidden = !(_renderingMode == DMPagerNavigationBarItemModeOnlyImage || _renderingMode == DMPagerNavigationBarItemModeTextAndImage);
+    [self layoutSubviews];
 }
-
 - (void)layoutSubviews {
 	[super layoutSubviews];
 


### PR DESCRIPTION
Fixes a bug when `renderingMode` is set to `DMPagerNavigationBarItemModeOnlyImage`.
